### PR TITLE
Fix use-after-free

### DIFF
--- a/src/semantics/validate/validate-func.c
+++ b/src/semantics/validate/validate-func.c
@@ -139,13 +139,15 @@ int validate_bstmt(struct yf_parse_node * cin, struct yf_ast_node * ain,
             fdata->error = 1;
             err = 1;
         } else {
+
             /* Move to abstract list */
             yf_list_add(&a->stmts, asub);
-        }
 
-        /* Probably redundant */
-        if (asub->type == YFA_RETURN) {
-            *returns = 1;
+            /* Probably redundant */
+            if (asub->type == YFA_RETURN) {
+                *returns = 1;
+            }
+            
         }
 
         /* Keep going */


### PR DESCRIPTION
In block statement validation, a node would still be checked for returning a value even if validation had given an error and the node had been freed.